### PR TITLE
Rework mlpoc locking with internal subcommands

### DIFF
--- a/mlpoc
+++ b/mlpoc
@@ -36,7 +36,7 @@ log_switch(){ # $1: model, $2: before, $3: after
 }
 
 with_lock(){ # $1: model, $2...: command
-  local model="$1"; shift || die "with_lock requires command"
+  local model="$1"; shift || die "with_lock requires model and command arguments"
   local lock="/var/lock/mlpoc.${model}.lock"
   sudo mkdir -p /var/lock
   exec 9>"$lock"


### PR DESCRIPTION
## Summary
- add a with_lock helper that coordinates per-model locks under /var/lock
- execute link switching and install steps through hidden __locked-* subcommands so flock can run the script directly
- wrap pull, pull-switch, and switch link updates in the new locking helper

## Testing
- bash -n mlpoc

------
https://chatgpt.com/codex/tasks/task_e_68cd883bae1083299713a2946d9839dd